### PR TITLE
Fix workflow to upload binary when new tag is created

### DIFF
--- a/.github/workflows/hcsctl.yml
+++ b/.github/workflows/hcsctl.yml
@@ -68,7 +68,6 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: hcsctl
-          working-directory: hcsctl
           path: | 
-            build/hcsctl
-            bild/hcsctl.test
+            hcsctl/build/hcsctl
+            hcsctl/bild/hcsctl.test


### PR DESCRIPTION
- Setting working-directory is not supported for Upload-Artifact action
- Change binary path to be relative from the root directory of the project