### PR TITLE
Remove e2e testcases

### DIFF
--- a/.github/workflows/hcsctl.yml
+++ b/.github/workflows/hcsctl.yml
@@ -46,8 +46,6 @@ jobs:
         config:
         - {k8s: v1.17.9, network: calico}
         - {k8s: v1.17.9, network: flannel}
-        - {k8s: v1.15.3, network: calico}
-        - {k8s: v1.15.3, network: flannel}
     steps:
       - run: |
           export BOX_OS=prolinux KUBE_VERSION=${{ matrix.config.k8s }} KUBE_NETWORK=${{ matrix.config.network }}


### PR DESCRIPTION
- remove k8s v1.15 e2e testcases
- minimum supported k8s version is now v1.17