### PR TITLE
Fix workflow to upload binary when release is published

### DIFF
--- a/.github/workflows/hcsctl.yml
+++ b/.github/workflows/hcsctl.yml
@@ -3,9 +3,10 @@ on:
   push:
     branches:
       - master
-    tags:
-      - v*
   pull_request:
+  release:
+    types:
+      - published
 defaults:
   run:
     working-directory: hcsctl
@@ -57,18 +58,26 @@ jobs:
           build/hcsctl uninstall ../hack/inventory/test-sample
           build/hcsctl uninstall ../hack/inventory/test-sample # idempotent
           ../hack/prolinux_cluster.sh down
-  release:
-    if: startsWith(github.ref, 'refs/tags/v')
+  deploy:
+    if: github.event_name == 'release'
     needs: [lint, build, e2e]
     runs-on: prolinux
     steps:
       - name: Upload hcsctl binary
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: hcsctl
-          path: hcsctl/build/
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: hcsctl/build/
+          asset_name: hcsctl
+          asset_content_type: application/octet-stream
       - name: Upload hcsctl.test binary
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: hcsctl.test
-          path: hcsctl/build/
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: hcsctl/build/
+          asset_name: hcsctl.test
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
- actions/upload-artifact uploads binary to github action page
- actions/upload-release-asset is needed to upload files to release page
  - upload_url of the specific release is needed which can not retrieve from push webhook event