### PR TITLE
Fix workflow to upload binary when release is published

### DIFF
--- a/.github/workflows/hcsctl.yml
+++ b/.github/workflows/hcsctl.yml
@@ -69,7 +69,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: hcsctl/build/
+          asset_path: hcsctl/build/hcsctl
           asset_name: hcsctl
           asset_content_type: application/octet-stream
       - name: Upload hcsctl.test binary
@@ -78,6 +78,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: hcsctl/build/
+          asset_path: hcsctl/build/hcsctl.test
           asset_name: hcsctl.test
           asset_content_type: application/octet-stream


### PR DESCRIPTION
- change asset_path on actions/upload-release-asset to point to a file, not diredtory