### PR TITLE
Add rook upgrade from 1.3 to 1.4

### DIFF
--- a/docs/block-multipool.md
+++ b/docs/block-multipool.md
@@ -1,0 +1,138 @@
+# 스토리지 종류에 따른 rbd 볼륨 생성 방법
+
+> 해당 문서는 rbd에서 storage 종류 (hdd/ssd/nvme)에 따라 서로 다른 pool에 볼륨 생성을 하는 방법을 설명합니다.
+
+
+## HOWTO
+
+1. 구분하고 싶은 storage 종류만큼 rbd pool을 생성합니다.
+
+- 스토리지 종류 개수만큼 CephBlockPool CR을 생성합니다.
+  - 아래 예시처럼 hdd/ssd/nvme에 대해서 각각의 CR을 생성할 수 있습니다.
+
+    ```yaml
+    apiVersion: ceph.rook.io/v1
+    kind: CephBlockPool
+    metadata:
+      name: replicapool-hdd   ## hdd를 위한 rbd pool
+      namespace: rook-ceph
+    spec:
+      failureDomain: host
+      replicated:
+        size: 2
+    ``` 
+    
+- 위와 같이 스토리지 별로 CephBlockPool CR을 생성하면 여러 rbd pool이 생성되는 것을 확인할 수 있습니다.
+
+    ```shell
+    ## toolbox에서 해당 command 실행
+    $ ceph osd pool ls
+    
+    ...  ## 다른 pool들은 생략
+    
+    replicapool-hdd
+    replicapool-ssd
+    replicapool-nvme
+    ```
+    
+2. toolbox에서 여러 pool에 대하여 다른 스토리지를 사용하도록 CRUSH rule을 설정합니다.
+ 
+- 스토리지 종류에 따른 CRUSH rule을 생성합니다.
+  - Command: `ceph osd crush rule create-replicated <rule-name> <root> <failure-domain> <class>`
+
+    ```shell
+    ## toolbox에서 해당 command 실행
+    $ ceph osd crush rule create-replicated hdd_rule default host hdd     ## hdd 스토리지에 대한 CRUSH rule
+    $ ceph osd crush rule create-replicated ssd_rule default host ssd     ## ssd 스토리지에 대한 CRUSH rule
+    $ ceph osd crush rule create-replicated nvme_rule default host nvme   ## nvme 스토리지에 대한 CRUSH rule
+    ```
+
+- CRUSH rule을 pool에 적용합니다.
+  - Command: `ceph osd pool set <pool-name> crush_rule <rule-name>`
+  - 참고: metadata pool에도 다음 방법으로 CRUSH rule을 적용할 수 있습니다.
+
+    ```shell
+    ## toolbox에서 해당 command 실행
+    $ ceph osd pool set replicapool-hdd crush_rule hdd_rule    ## replicapool-hdd pool에 hdd에 대한 CRUSH rule을 적용
+    set pool 8 crush_rule to hdd_rule
+    $ ceph osd pool set replicapool-ssd crush_rule ssd_rule    ## replicapool-ssd pool에 ssd에 대한 CRUSH rule을 적용
+    set pool 9 crush_rule to ssd_rule
+    $ ceph osd pool set replicapool-nvme crush_rule nvme_rule   ## replicapool-nvme pool에 nvme에 대한 CRUSH rule을 적용
+    set pool 10 crush_rule to nvme_rule
+    ```
+  
+3. 스토리지 종류에 따른 storage class를 생성합니다. 
+
+- storage class의 파라미터 중 pool 필드를 스토리지 종류에 맞는 pool로 명시하여 적용합니다.
+
+    ```yaml
+    apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+       name: rook-ceph-block-hdd   ## hdd를 사용할 storage class
+    provisioner: rook-ceph.rbd.csi.ceph.com
+    parameters:
+        clusterID: rook-ceph
+    
+        pool: replicapool-hdd   ## replicapool-hdd는 hdd_rule이 적용된 pool
+    
+        imageFormat: "2"
+    
+        imageFeatures: layering
+    
+        csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+        csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+        csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+        csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+        csi.storage.k8s.io/fstype: ext4
+    reclaimPolicy: Delete
+    ```
+    
+- 스토리지 종류들에 따라 위 예시대로 storage class들을 생성합니다.
+
+- 사용자는 pvc를 만들 때 원하는 storage class를 선택해서 스토리지 종류대로 rbd를 이용 가능합니다.
+
+
+
+## 작업이 제대로 수행되었는지 확인하기
+
+> Storage 종류에 따라 pool 이 잘 생성되었는지는 Ceph Placement Group (pg) 조회를 통해 확인할 수 있습니다.
+
+
+1. 어떤 osd들이 어떤 Storage 종류에 속하는지를 파악합니다.
+- Command: `ceph osd df | awk '{print $1, $2}'`
+
+    ```shell
+    ## toolbox에서 해당 command 실행
+    $ ceph osd df | awk '{print $1, $2}'
+    
+    ID CLASS
+    2 hdd   ## osd 2는 HDD에 속함
+    5 ssd   ## osd 5는 SSD에 속함
+    4 hdd   ## osd 4는 HDD에 속함
+    1 ssd   ## osd 1은 SSD에 속함
+    3 hdd   ## osd 3은 HDD에 속함
+    0 ssd   ## osd 0은 SSD에 속함
+    ...
+    ```
+
+2. pool의 pg들이 Storage 종류에 속하는 osd들을 acting set으로 가지고 있는지 확인합니다.
+- Command: `ceph pg dump | awk '{print $1, $19}'`
+
+    ```shell
+    ## toolbox에서 해당 command 실행
+    $ ceph pg dump | awk '{print $1, $19}'
+    
+    ## 앞서 확인했듯이 HDD osd는 2,3,4, SSD osd는 0,1,5
+    ...
+    PG_STAT ACTING_PRIMARY
+    9.16 [1,5]   ## pool 9의 pg 0x16은 acting set으로 osd 1,5를 가짐 (SSD osd)
+    8.15 [4,3]   ## pool 8의 pg 0x15는 acting set으로 osd 4,3을 가짐 (HDD osd)
+    9.17 [0,5]   ## pool 9의 pg 0x17은 acting set으로 osd 0,5를 가짐 (SSD osd)
+    8.13 [2,4]   ## pool 8의 pg 0x13은 acting set으로 osd 2,4를 가짐 (HDD osd)
+    9.12 [0,1]   ## pool 9의 pg 0x12은 acting set으로 osd 0,1를 가짐 (SSD osd)
+    8.11 [3,2]   ## pool 8의 pg 0x11은 acting set으로 osd 3,2를 가짐 (HDD osd)
+    ...
+    ```
+    - 위와 같이 각 pool의 모든 pg에 대해서 Storage 종류에 따른 osd들로 mapping 됐는지 확인하면 됩니다.
+

--- a/docs/file-multipool.md
+++ b/docs/file-multipool.md
@@ -1,0 +1,157 @@
+# 스토리지 종류에 따른 CephFS 볼륨 생성 방법
+
+> 해당 문서는 CephFS에서 storage 종류(hdd/ssd/nvme)에 따라 서로 다른 pool에 볼륨 생성을 하는 방법을 설명합니다.
+
+
+## 주의사항
+
+metadata pool은 여러 pool이 생성되지 않으므로 storage 종류에 따른 메타데이터 저장을 할 수 없습니다.
+
+
+## HOWTO
+
+1. CephFS의 data pool을 구분하고 싶은 storage 종류만큼 생성합니다.
+
+- CephFileSystem CR을 여러 data pool을 사용하도록 생성합니다.
+  - 참고: metadata pool은 multi-pool이 지원되지 않아 한 개의 pool로만 생성 가능합니다.
+
+    ```yaml
+    apiVersion: ceph.rook.io/v1
+    kind: CephFilesystem
+    metadata:
+      name: myfs
+      namespace: rook-ceph
+    spec:
+      metadataPool:
+        failureDomain: host
+        replicated:
+          size: 2
+          
+      ## 여러 개의 data pool 생성
+      dataPools:
+        - failureDomain: host   ## hdd를 위한 pool
+          replicated:
+            size: 2
+        - failureDomain: host   ## ssd를 위한 pool
+          replicated:
+            size: 2
+        - failureDomain: host   ## nvme를 위한 pool
+          replicated:
+            size: 2
+      
+      metadataServer:
+        activeCount: 1
+        activeStandby: true
+    ``` 
+
+- 위와 같은 yaml 파일을 적용하면 여러 data pool을 가지는 CephFS가 생성되는 것을 확인할 수 있습니다.
+
+    ```shell
+    ## toolbox에서 해당 command 실행
+    $ ceph osd pool ls
+    myfs-metadata
+    myfs-data0
+    myfs-data1
+    myfs-data2
+    ```
+
+
+2. toolbox에서 여러 pool에 대하여 다른 스토리지를 사용하도록 CRUSH rule을 설정합니다.
+ 
+- 스토리지 종류에 따른 CRUSH rule을 생성합니다.
+  - Command: `ceph osd crush rule create-replicated <rule-name> <root> <failure-domain> <class>`
+
+    ```shell
+    ## toolbox에서 해당 command 실행
+    $ ceph osd crush rule create-replicated hdd_rule default host hdd     ## hdd 스토리지에 대한 CRUSH rule
+    $ ceph osd crush rule create-replicated ssd_rule default host ssd     ## ssd 스토리지에 대한 CRUSH rule
+    $ ceph osd crush rule create-replicated nvme_rule default host nvme   ## nvme 스토리지에 대한 CRUSH rule
+    ```
+
+- CRUSH rule을 pool에 적용합니다.
+  - Command: `ceph osd pool set <pool-name> crush_rule <rule-name>`
+  - 참고: metadata pool에도 다음 방법으로 CRUSH rule을 적용할 수 있습니다.
+
+    ```shell
+    ## toolbox에서 해당 command 실행
+    $ ceph osd pool set myfs-data0 crush_rule hdd_rule    ## myfs-data0 pool에 hdd에 대한 CRUSH rule을 적용
+    set pool 5 crush_rule to hdd_rule
+    $ ceph osd pool set myfs-data1 crush_rule ssd_rule    ## myfs-data1 pool에 ssd에 대한 CRUSH rule을 적용
+    set pool 6 crush_rule to ssd_rule
+    $ ceph osd pool set myfs-data2 crush_rule nvme_rule   ## myfs-data2 pool에 nvme에 대한 CRUSH rule을 적용
+    set pool 7 crush_rule to nvme_rule
+    ```
+  
+3. 스토리지 종류에 따른 storage class를 생성합니다. 
+
+- storage class의 파라미터 중 pool 필드를 스토리지 종류에 맞는 pool로 명시하여 적용합니다.
+
+    ```yaml
+    apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+      name: cephfs-sc-hdd   ## hdd 스토리지를 사용할 storage class
+    provisioner: rook-ceph.cephfs.csi.ceph.com
+    parameters:
+      clusterID: rook-ceph
+      fsName: myfs
+      
+      ## 스토리지 종류에 따른 CRUSH rule이 적용된 pool을 명시합니다
+      pool: myfs-data0   ## myfs-data0는 hdd_rule이 적용된 pool
+    
+      csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+      csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+      csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+      csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+    
+    reclaimPolicy: Delete
+    mountOptions:
+    ```
+    
+- 스토리지 종류들에 따라 위 예시대로 storage class들을 생성합니다.
+
+- 사용자는 pvc를 만들 때 원하는 storage class를 선택해서 스토리지 종류대로 CephFS 이용 가능합니다.
+
+
+## 작업이 제대로 수행되었는지 확인하기
+
+> Storage 종류에 따라 pool 이 잘 생성되었는지는 Ceph Placement Group (pg) 조회를 통해 확인할 수 있습니다.
+
+
+1. 어떤 osd들이 어떤 Storage 종류에 속하는지를 파악합니다.
+- Command: `ceph osd df | awk '{print $1, $2}'`
+
+    ```shell
+    ## toolbox에서 해당 command 실행
+    $ ceph osd df | awk '{print $1, $2}'
+    
+    ID CLASS
+    2 hdd   ## osd 2는 HDD에 속함
+    5 ssd   ## osd 5는 SSD에 속함
+    4 hdd   ## osd 4는 HDD에 속함
+    1 ssd   ## osd 1은 SSD에 속함
+    3 hdd   ## osd 3은 HDD에 속함
+    0 ssd   ## osd 0은 SSD에 속함
+    ...
+    ```
+
+2. pool의 pg들이 Storage 종류에 속하는 osd들을 acting set으로 가지고 있는지 확인합니다.
+- Command: `ceph pg dump | awk '{print $1, $19}'`
+
+    ```shell
+    ## toolbox에서 해당 command 실행
+    $ ceph pg dump | awk '{print $1, $19}'
+    
+    ## 앞서 확인했듯이 HDD osd는 2,3,4, SSD osd는 0,1,5
+    ...
+    PG_STAT ACTING_PRIMARY
+    6.16 [1,5]   ## pool 6의 pg 0x16은 acting set으로 osd 1,5를 가짐 (SSD osd)
+    5.15 [4,3]   ## pool 5의 pg 0x15는 acting set으로 osd 4,3을 가짐 (HDD osd)
+    6.17 [0,5]   ## pool 6의 pg 0x17은 acting set으로 osd 0,5를 가짐 (SSD osd)
+    5.13 [2,4]   ## pool 5의 pg 0x13은 acting set으로 osd 2,4를 가짐 (HDD osd)
+    6.12 [0,1]   ## pool 6의 pg 0x12은 acting set으로 osd 0,1를 가짐 (SSD osd)
+    5.11 [3,2]   ## pool 5의 pg 0x11은 acting set으로 osd 3,2를 가짐 (HDD osd)
+    ...
+    ```
+    - 위와 같이 각 pool의 모든 pg에 대해서 Storage 종류에 따른 osd들로 mapping 됐는지 확인하면 됩니다.
+

--- a/docs/upgrade/1_snapshot_crds.yaml
+++ b/docs/upgrade/1_snapshot_crds.yaml
@@ -1,0 +1,508 @@
+---
+## VolumeSnapshot
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
+  creationTimestamp: null
+  name: volumesnapshots.snapshot.storage.k8s.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.readyToUse
+    description: Indicates if a snapshot is ready to be used to restore a volume.
+    name: ReadyToUse
+    type: boolean
+  - JSONPath: .spec.source.persistentVolumeClaimName
+    description: Name of the source PVC from where a dynamically taken snapshot will
+      be created.
+    name: SourcePVC
+    type: string
+  - JSONPath: .spec.source.volumeSnapshotContentName
+    description: Name of the VolumeSnapshotContent which represents a pre-provisioned
+      snapshot.
+    name: SourceSnapshotContent
+    type: string
+  - JSONPath: .status.restoreSize
+    description: Represents the complete size of the snapshot.
+    name: RestoreSize
+    type: string
+  - JSONPath: .spec.volumeSnapshotClassName
+    description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+    name: SnapshotClass
+    type: string
+  - JSONPath: .status.boundVolumeSnapshotContentName
+    description: The name of the VolumeSnapshotContent to which this VolumeSnapshot
+      is bound.
+    name: SnapshotContent
+    type: string
+  - JSONPath: .status.creationTime
+    description: Timestamp when the point-in-time snapshot is taken by the underlying
+      storage system.
+    name: CreationTime
+    type: date
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshot
+    listKind: VolumeSnapshotList
+    plural: volumesnapshots
+    singular: volumesnapshot
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshot is a user's request for either creating a point-in-time
+        snapshot of a persistent volume, or binding to a pre-existing snapshot.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'spec defines the desired characteristics of a snapshot requested
+            by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+            Required.'
+          properties:
+            source:
+              description: source specifies where a snapshot will be created from.
+                This field is immutable after creation. Required.
+              properties:
+                persistentVolumeClaimName:
+                  description: persistentVolumeClaimName specifies the name of the
+                    PersistentVolumeClaim object in the same namespace as the VolumeSnapshot
+                    object where the snapshot should be dynamically taken from. This
+                    field is immutable.
+                  type: string
+                volumeSnapshotContentName:
+                  description: volumeSnapshotContentName specifies the name of a pre-existing
+                    VolumeSnapshotContent object. This field is immutable.
+                  type: string
+              type: object
+            volumeSnapshotClassName:
+              description: 'volumeSnapshotClassName is the name of the VolumeSnapshotClass
+                requested by the VolumeSnapshot. If not specified, the default snapshot
+                class will be used if one exists. If not specified, and there is no
+                default snapshot class, dynamic snapshot creation will fail. Empty
+                string is not allowed for this field. TODO(xiangqian): a webhook validation
+                on empty string. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes'
+              type: string
+          required:
+          - source
+          type: object
+        status:
+          description: 'status represents the current information of a snapshot. NOTE:
+            status can be modified by sources other than system controllers, and must
+            not be depended upon for accuracy. Controllers should only use information
+            from the VolumeSnapshotContent object after verifying that the binding
+            is accurate and complete.'
+          properties:
+            boundVolumeSnapshotContentName:
+              description: 'boundVolumeSnapshotContentName represents the name of
+                the VolumeSnapshotContent object to which the VolumeSnapshot object
+                is bound. If not specified, it indicates that the VolumeSnapshot object
+                has not been successfully bound to a VolumeSnapshotContent object
+                yet. NOTE: Specified boundVolumeSnapshotContentName alone does not
+                mean binding       is valid. Controllers MUST always verify bidirectional
+                binding between       VolumeSnapshot and VolumeSnapshotContent to
+                avoid possible security issues.'
+              type: string
+            creationTime:
+              description: creationTime is the timestamp when the point-in-time snapshot
+                is taken by the underlying storage system. In dynamic snapshot creation
+                case, this field will be filled in with the "creation_time" value
+                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
+                snapshot, this field will be filled with the "creation_time" value
+                returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                it. If not specified, it indicates that the creation time of the snapshot
+                is unknown.
+              format: date-time
+              type: string
+            error:
+              description: error is the last observed error during snapshot creation,
+                if any. This field could be helpful to upper level controllers(i.e.,
+                application controller) to decide whether they should continue on
+                waiting for the snapshot to be created based on the type of error
+                reported.
+              properties:
+                message:
+                  description: 'message is a string detailing the encountered error
+                    during snapshot creation if specified. NOTE: message may be logged,
+                    and it should not contain sensitive information.'
+                  type: string
+                time:
+                  description: time is the timestamp when the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            readyToUse:
+              description: readyToUse indicates if a snapshot is ready to be used
+                to restore a volume. In dynamic snapshot creation case, this field
+                will be filled in with the "ready_to_use" value returned from CSI
+                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
+                field will be filled with the "ready_to_use" value returned from the
+                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
+                this field will be set to "True". If not specified, it means the readiness
+                of a snapshot is unknown.
+              type: boolean
+            restoreSize:
+              anyOf:
+              - type: integer
+              - type: string
+              description: restoreSize represents the complete size of the snapshot
+                in bytes. In dynamic snapshot creation case, this field will be filled
+                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                gRPC call. For a pre-existing snapshot, this field will be filled
+                with the "size_bytes" value returned from the CSI "ListSnapshots"
+                gRPC call if the driver supports it. When restoring a volume from
+                this snapshot, the size of the volume MUST NOT be smaller than the
+                restoreSize if it is specified, otherwise the restoration will fail.
+                If not specified, it indicates that the size is unknown.
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+## VolumeSnapshotContent
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
+  creationTimestamp: null
+  name: volumesnapshotcontents.snapshot.storage.k8s.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.readyToUse
+    description: Indicates if a snapshot is ready to be used to restore a volume.
+    name: ReadyToUse
+    type: boolean
+  - JSONPath: .status.restoreSize
+    description: Represents the complete size of the snapshot in bytes
+    name: RestoreSize
+    type: integer
+  - JSONPath: .spec.deletionPolicy
+    description: Determines whether this VolumeSnapshotContent and its physical snapshot
+      on the underlying storage system should be deleted when its bound VolumeSnapshot
+      is deleted.
+    name: DeletionPolicy
+    type: string
+  - JSONPath: .spec.driver
+    description: Name of the CSI driver used to create the physical snapshot on the
+      underlying storage system.
+    name: Driver
+    type: string
+  - JSONPath: .spec.volumeSnapshotClassName
+    description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+    name: VolumeSnapshotClass
+    type: string
+  - JSONPath: .spec.volumeSnapshotRef.name
+    description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent
+      object is bound.
+    name: VolumeSnapshot
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotContent
+    listKind: VolumeSnapshotContentList
+    plural: volumesnapshotcontents
+    singular: volumesnapshotcontent
+  preserveUnknownFields: false
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotContent represents the actual "on-disk" snapshot
+        object in the underlying storage system
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: spec defines properties of a VolumeSnapshotContent created
+            by the underlying storage system. Required.
+          properties:
+            deletionPolicy:
+              description: deletionPolicy determines whether this VolumeSnapshotContent
+                and its physical snapshot on the underlying storage system should
+                be deleted when its bound VolumeSnapshot is deleted. Supported values
+                are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
+                and its physical snapshot on underlying storage system are kept. "Delete"
+                means that the VolumeSnapshotContent and its physical snapshot on
+                underlying storage system are deleted. In dynamic snapshot creation
+                case, this field will be filled in with the "DeletionPolicy" field
+                defined in the VolumeSnapshotClass the VolumeSnapshot refers to. For
+                pre-existing snapshots, users MUST specify this field when creating
+                the VolumeSnapshotContent object. Required.
+              enum:
+              - Delete
+              - Retain
+              type: string
+            driver:
+              description: driver is the name of the CSI driver used to create the
+                physical snapshot on the underlying storage system. This MUST be the
+                same as the name returned by the CSI GetPluginName() call for that
+                driver. Required.
+              type: string
+            source:
+              description: source specifies from where a snapshot will be created.
+                This field is immutable after creation. Required.
+              properties:
+                snapshotHandle:
+                  description: snapshotHandle specifies the CSI "snapshot_id" of a
+                    pre-existing snapshot on the underlying storage system. This field
+                    is immutable.
+                  type: string
+                volumeHandle:
+                  description: volumeHandle specifies the CSI "volume_id" of the volume
+                    from which a snapshot should be dynamically taken from. This field
+                    is immutable.
+                  type: string
+              type: object
+            volumeSnapshotClassName:
+              description: name of the VolumeSnapshotClass to which this snapshot
+                belongs.
+              type: string
+            volumeSnapshotRef:
+              description: volumeSnapshotRef specifies the VolumeSnapshot object to
+                which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
+                field must reference to this VolumeSnapshotContent's name for the
+                bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
+                object, name and namespace of the VolumeSnapshot object MUST be provided
+                for binding to happen. This field is immutable after creation. Required.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+          required:
+          - deletionPolicy
+          - driver
+          - source
+          - volumeSnapshotRef
+          type: object
+        status:
+          description: status represents the current information of a snapshot.
+          properties:
+            creationTime:
+              description: creationTime is the timestamp when the point-in-time snapshot
+                is taken by the underlying storage system. In dynamic snapshot creation
+                case, this field will be filled in with the "creation_time" value
+                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
+                snapshot, this field will be filled with the "creation_time" value
+                returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                it. If not specified, it indicates the creation time is unknown. The
+                format of this field is a Unix nanoseconds time encoded as an int64.
+                On Unix, the command `date +%s%N` returns the current time in nanoseconds
+                since 1970-01-01 00:00:00 UTC.
+              format: int64
+              type: integer
+            error:
+              description: error is the latest observed error during snapshot creation,
+                if any.
+              properties:
+                message:
+                  description: 'message is a string detailing the encountered error
+                    during snapshot creation if specified. NOTE: message may be logged,
+                    and it should not contain sensitive information.'
+                  type: string
+                time:
+                  description: time is the timestamp when the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            readyToUse:
+              description: readyToUse indicates if a snapshot is ready to be used
+                to restore a volume. In dynamic snapshot creation case, this field
+                will be filled in with the "ready_to_use" value returned from CSI
+                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
+                field will be filled with the "ready_to_use" value returned from the
+                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
+                this field will be set to "True". If not specified, it means the readiness
+                of a snapshot is unknown.
+              type: boolean
+            restoreSize:
+              description: restoreSize represents the complete size of the snapshot
+                in bytes. In dynamic snapshot creation case, this field will be filled
+                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                gRPC call. For a pre-existing snapshot, this field will be filled
+                with the "size_bytes" value returned from the CSI "ListSnapshots"
+                gRPC call if the driver supports it. When restoring a volume from
+                this snapshot, the size of the volume MUST NOT be smaller than the
+                restoreSize if it is specified, otherwise the restoration will fail.
+                If not specified, it indicates that the size is unknown.
+              format: int64
+              minimum: 0
+              type: integer
+            snapshotHandle:
+              description: snapshotHandle is the CSI "snapshot_id" of a snapshot on
+                the underlying storage system. If not specified, it indicates that
+                dynamic snapshot creation has either failed or it is still in progress.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+## VolumeSnapshotClass
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
+  creationTimestamp: null
+  name: volumesnapshotclasses.snapshot.storage.k8s.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .driver
+    name: Driver
+    type: string
+  - JSONPath: .deletionPolicy
+    description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass
+      should be deleted when its bound VolumeSnapshot is deleted.
+    name: DeletionPolicy
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotClass
+    listKind: VolumeSnapshotClassList
+    plural: volumesnapshotclasses
+    singular: volumesnapshotclass
+  preserveUnknownFields: false
+  scope: Cluster
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotClass specifies parameters that a underlying storage
+        system uses when creating a volume snapshot. A specific VolumeSnapshotClass
+        is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
+        are non-namespaced
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        deletionPolicy:
+          description: deletionPolicy determines whether a VolumeSnapshotContent created
+            through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot
+            is deleted. Supported values are "Retain" and "Delete". "Retain" means
+            that the VolumeSnapshotContent and its physical snapshot on underlying
+            storage system are kept. "Delete" means that the VolumeSnapshotContent
+            and its physical snapshot on underlying storage system are deleted. Required.
+          enum:
+          - Delete
+          - Retain
+          type: string
+        driver:
+          description: driver is the name of the storage driver that handles this
+            VolumeSnapshotClass. Required.
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        parameters:
+          additionalProperties:
+            type: string
+          description: parameters is a key-value map with storage driver specific
+            parameters for creating snapshots. These values are opaque to Kubernetes.
+          type: object
+      required:
+      - deletionPolicy
+      - driver
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/docs/upgrade/2_snapshot_controller_rbac.yaml
+++ b/docs/upgrade/2_snapshot_controller_rbac.yaml
@@ -1,0 +1,80 @@
+# RBAC file for the snapshot controller.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-controller
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # rename if there are conflicts
+  name: snapshot-controller-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  # change the name also here if the ClusterRole gets renamed
+  name: snapshot-controller-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default # TODO: replace with the namespace you want for your controller
+  name: snapshot-controller-leaderelection
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-leaderelection
+  namespace: default # TODO: replace with the namespace you want for your controller
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller
+    namespace: default # TODO: replace with the namespace you want for your controller
+roleRef:
+  kind: Role
+  name: snapshot-controller-leaderelection
+  apiGroup: rbac.authorization.k8s.io
+

--- a/docs/upgrade/3_snapshot_controller.yaml
+++ b/docs/upgrade/3_snapshot_controller.yaml
@@ -1,0 +1,26 @@
+# This YAML file shows how to deploy the snapshot controller
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: snapshot-controller
+spec:
+  serviceName: "snapshot-controller"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: snapshot-controller
+  template:
+    metadata:
+      labels:
+        app: snapshot-controller
+    spec:
+      serviceAccount: snapshot-controller
+      containers:
+        - name: snapshot-controller
+          image: quay.io/k8scsi/snapshot-controller:v2.0.1
+          args:
+            - "--v=5"
+            - "--leader-election=false"
+          imagePullPolicy: Always

--- a/docs/upgrade/4_rook_rbac_v1_3.yaml
+++ b/docs/upgrade/4_rook_rbac_v1_3.yaml
@@ -1,0 +1,79 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cephfs-csi-nodeplugin-rules
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cephfs-external-provisioner-runner-rules
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rbd-csi-nodeplugin-rules
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rbd-external-provisioner-runner-rules
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-cluster-mgmt-rules
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-global-rules
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-mgr-cluster-rules
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-mgr-system-rules
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cephfs-csi-nodeplugin
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cephfs-external-provisioner-runner
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rbd-csi-nodeplugin
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rbd-external-provisioner-runner
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-cluster-mgmt
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-global
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-mgr-cluster
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-mgr-system

--- a/docs/upgrade/5_rook_rbac_v1_4.yaml
+++ b/docs/upgrade/5_rook_rbac_v1_4.yaml
@@ -1,0 +1,381 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-global
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+- apiGroups:
+  - ""
+  resources:
+  # Pod access is needed for fencing
+  - pods
+  # Node access is needed for determining nodes where mons should run
+  - nodes
+  - nodes/proxy
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+    # PVs and PVCs are managed by the Rook provisioner
+  - persistentvolumes
+  - persistentvolumeclaims
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ceph.rook.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - rook.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  - apps
+  - extensions
+  resources:
+  # This is for the clusterdisruption controller
+  - poddisruptionbudgets
+  # This is for both clusterdisruption and nodedrain controllers
+  - deployments
+  - replicasets
+  verbs:
+  - "*"
+- apiGroups:
+  - healthchecking.openshift.io
+  resources:
+  - machinedisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machines
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-cluster-mgmt
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+- apiGroups:
+  - ""
+  - apps
+  - extensions
+  resources:
+  - secrets
+  - pods
+  - pods/log
+  - services
+  - configmaps
+  - deployments
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - create
+  - update
+  - delete
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-mgr-cluster
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - nodes/proxy
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - list
+  - get
+  - watch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-object-bucket
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+- apiGroups:
+  - ""
+  verbs:
+  - "*"
+  resources:
+  - secrets
+  - configmaps
+- apiGroups:
+    - storage.k8s.io
+  resources:
+    - storageclasses
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+  - "objectbucket.io"
+  verbs:
+  - "*"
+  resources:
+  - "*"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-mgr-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-csi-nodeplugin
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-external-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete", "get", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rbd-csi-nodeplugin
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rbd-external-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete", "get", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-admission-controller
+  namespace: rook-ceph
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-admission-controller-role
+rules:
+  - apiGroups: ["ceph.rook.io"]
+    resources: ["*"]
+    verbs: ["get", "watch", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-admission-controller-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-admission-controller
+    apiGroup: ""
+    namespace: rook-ceph
+roleRef:
+  kind: ClusterRole
+  name: rook-ceph-admission-controller-role
+  apiGroup: rbac.authorization.k8s.io

--- a/docs/upgrade/6_rook_crds_v1_4.yaml
+++ b/docs/upgrade/6_rook_crds_v1_4.yaml
@@ -1,0 +1,704 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephclusters.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephCluster
+    listKind: CephClusterList
+    plural: cephclusters
+    singular: cephcluster
+  scope: Namespaced
+  version: v1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            annotations: {}
+            cephVersion:
+              properties:
+                allowUnsupported:
+                  type: boolean
+                image:
+                  type: string
+            dashboard:
+              properties:
+                enabled:
+                  type: boolean
+                urlPrefix:
+                  type: string
+                port:
+                  type: integer
+                  minimum: 0
+                  maximum: 65535
+                ssl:
+                  type: boolean
+            dataDirHostPath:
+              pattern: ^/(\S+)
+              type: string
+            disruptionManagement:
+              properties:
+                machineDisruptionBudgetNamespace:
+                  type: string
+                managePodBudgets:
+                  type: boolean
+                osdMaintenanceTimeout:
+                  type: integer
+                manageMachineDisruptionBudgets:
+                  type: boolean
+            skipUpgradeChecks:
+              type: boolean
+            continueUpgradeAfterChecksEvenIfNotHealthy:
+              type: boolean
+            mon:
+              properties:
+                allowMultiplePerNode:
+                  type: boolean
+                count:
+                  maximum: 9
+                  minimum: 0
+                  type: integer
+                volumeClaimTemplate: {}
+            mgr:
+              properties:
+                modules:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      enabled:
+                        type: boolean
+            network:
+              properties:
+                hostNetwork:
+                  type: boolean
+                provider:
+                  type: string
+                selectors: {}
+            storage:
+              properties:
+                disruptionManagement:
+                  properties:
+                    machineDisruptionBudgetNamespace:
+                      type: string
+                    managePodBudgets:
+                      type: boolean
+                    osdMaintenanceTimeout:
+                      type: integer
+                    manageMachineDisruptionBudgets:
+                      type: boolean
+                useAllNodes:
+                  type: boolean
+                nodes:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      config:
+                        properties:
+                          metadataDevice:
+                            type: string
+                          storeType:
+                            type: string
+                            pattern: ^(bluestore)$
+                          databaseSizeMB:
+                            type: string
+                          walSizeMB:
+                            type: string
+                          journalSizeMB:
+                            type: string
+                          osdsPerDevice:
+                            type: string
+                          encryptedDevice:
+                            type: string
+                            pattern: ^(true|false)$
+                      useAllDevices:
+                        type: boolean
+                      deviceFilter:
+                        type: string
+                      devicePathFilter:
+                        type: string
+                      devices:
+                        type: array
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            config: {}
+                      resources: {}
+                  type: array
+                useAllDevices:
+                  type: boolean
+                deviceFilter:
+                  type: string
+                devicePathFilter:
+                  type: string
+                config: {}
+                storageClassDeviceSets: {}
+            driveGroups:
+              type: array
+              nullable: true
+              items:
+                properties:
+                  name:
+                    type: string
+                  spec: {}
+                  placement: {}
+                required:
+                - name
+                - spec
+            monitoring:
+              properties:
+                enabled:
+                  type: boolean
+                rulesNamespace:
+                  type: string
+                externalMgrEndpoints:
+                  type: array
+                  items:
+                    properties:
+                      ip:
+                        type: string
+            removeOSDsIfOutAndSafeToRemove:
+              type: boolean
+            external:
+              properties:
+                enable:
+                  type: boolean
+            cleanupPolicy:
+              properties:
+                confirmation:
+                  type: string
+                  pattern: ^$|^yes-really-destroy-data$
+                sanitizeDisks:
+                  properties:
+                    method:
+                      type: string
+                      pattern: ^(complete|quick)$
+                    dataSource:
+                      type: string
+                      pattern: ^(zero|random)$
+                    iteration:
+                      type: integer
+                      format: int32
+            placement: {}
+            resources: {}
+            healthCheck: {}
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+    - name: DataDirHostPath
+      type: string
+      description: Directory used on the K8s nodes
+      JSONPath: .spec.dataDirHostPath
+    - name: MonCount
+      type: string
+      description: Number of MONs
+      JSONPath: .spec.mon.count
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+    - name: Phase
+      type: string
+      description: Phase
+      JSONPath: .status.phase
+    - name: Message
+      type: string
+      description: Message
+      JSONPath: .status.message
+    - name: Health
+      type: string
+      description: Ceph Health
+      JSONPath: .status.ceph.health
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephclients.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephClient
+    listKind: CephClientList
+    plural: cephclients
+    singular: cephclient
+  scope: Namespaced
+  version: v1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            caps:
+              type: object
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephrbdmirrors.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephRBDMirror
+    listKind: CephRBDMirrorList
+    plural: cephrbdmirrors
+    singular: cephrbdmirror
+  scope: Namespaced
+  version: v1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            count:
+              type: integer
+              minimum: 1
+              maximum: 100
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephfilesystems.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephFilesystem
+    listKind: CephFilesystemList
+    plural: cephfilesystems
+    singular: cephfilesystem
+  scope: Namespaced
+  version: v1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            metadataServer:
+              properties:
+                activeCount:
+                  minimum: 1
+                  maximum: 10
+                  type: integer
+                activeStandby:
+                  type: boolean
+                annotations: {}
+                placement: {}
+                resources: {}
+            metadataPool:
+              properties:
+                failureDomain:
+                  type: string
+                crushRoot:
+                  type: string
+                replicated:
+                  properties:
+                    size:
+                      minimum: 0
+                      maximum: 10
+                      type: integer
+                    requireSafeReplicaSize:
+                      type: boolean
+                erasureCoded:
+                  properties:
+                    dataChunks:
+                      minimum: 0
+                      maximum: 10
+                      type: integer
+                    codingChunks:
+                      minimum: 0
+                      maximum: 10
+                      type: integer
+                compressionMode:
+                  type: string
+                  enum:
+                  - ""
+                  - none
+                  - passive
+                  - aggressive
+                  - force
+            dataPools:
+              type: array
+              items:
+                properties:
+                  failureDomain:
+                    type: string
+                  crushRoot:
+                    type: string
+                  replicated:
+                    properties:
+                      size:
+                        minimum: 0
+                        maximum: 10
+                        type: integer
+                      requireSafeReplicaSize:
+                        type: boolean
+                  erasureCoded:
+                    properties:
+                      dataChunks:
+                        minimum: 0
+                        maximum: 10
+                        type: integer
+                      codingChunks:
+                        minimum: 0
+                        maximum: 10
+                        type: integer
+                  compressionMode:
+                    type: string
+                    enum:
+                    - ""
+                    - none
+                    - passive
+                    - aggressive
+                    - force
+                  parameters:
+                    type: object
+            preservePoolsOnDelete:
+              type: boolean
+  additionalPrinterColumns:
+    - name: ActiveMDS
+      type: string
+      description: Number of desired active MDS daemons
+      JSONPath: .spec.metadataServer.activeCount
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephnfses.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephNFS
+    listKind: CephNFSList
+    plural: cephnfses
+    singular: cephnfs
+    shortNames:
+    - nfs
+  scope: Namespaced
+  version: v1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            rados:
+              properties:
+                pool:
+                  type: string
+                namespace:
+                  type: string
+            server:
+              properties:
+                active:
+                  type: integer
+                annotations: {}
+                placement: {}
+                resources: {}
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectstores.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectStore
+    listKind: CephObjectStoreList
+    plural: cephobjectstores
+    singular: cephobjectstore
+  scope: Namespaced
+  version: v1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            gateway:
+              properties:
+                type:
+                  type: string
+                sslCertificateRef: {}
+                port:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                securePort: {}
+                instances:
+                  type: integer
+                externalRgwEndpoints:
+                  type: array
+                  items:
+                    properties:
+                      ip:
+                        type: string
+                annotations: {}
+                placement: {}
+                resources: {}
+            metadataPool:
+              properties:
+                failureDomain:
+                  type: string
+                crushRoot:
+                  type: string
+                replicated:
+                  properties:
+                    size:
+                      type: integer
+                    requireSafeReplicaSize:
+                      type: boolean
+                erasureCoded:
+                  properties:
+                    dataChunks:
+                      type: integer
+                    codingChunks:
+                      type: integer
+                compressionMode:
+                  type: string
+                  enum:
+                  - ""
+                  - none
+                  - passive
+                  - aggressive
+                  - force
+                parameters:
+                  type: object
+            dataPool:
+              properties:
+                failureDomain:
+                  type: string
+                crushRoot:
+                  type: string
+                replicated:
+                  properties:
+                    size:
+                      type: integer
+                    requireSafeReplicaSize:
+                      type: boolean
+                erasureCoded:
+                  properties:
+                    dataChunks:
+                      type: integer
+                    codingChunks:
+                      type: integer
+                compressionMode:
+                  type: string
+                  enum:
+                  - ""
+                  - none
+                  - passive
+                  - aggressive
+                  - force
+                parameters:
+                  type: object
+            preservePoolsOnDelete:
+              type: boolean
+            healthCheck:
+              properties:
+                bucket:
+                  properties:
+                    enabled:
+                      type: boolean
+                    interval:
+                      type: string
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectstoreusers.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectStoreUser
+    listKind: CephObjectStoreUserList
+    plural: cephobjectstoreusers
+    singular: cephobjectstoreuser
+    shortNames:
+    - rcou
+    - objectuser
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectrealms.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectRealm
+    listKind: CephObjectRealmList
+    plural: cephobjectrealms
+    singular: cephobjectrealm
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectzonegroups.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectZoneGroup
+    listKind: CephObjectZoneGroupList
+    plural: cephobjectzonegroups
+    singular: cephobjectzonegroup
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectzones.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectZone
+    listKind: CephObjectZoneList
+    plural: cephobjectzones
+    singular: cephobjectzone
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephblockpools.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephBlockPool
+    listKind: CephBlockPoolList
+    plural: cephblockpools
+    singular: cephblockpool
+  scope: Namespaced
+  version: v1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            failureDomain:
+                type: string
+            crushRoot:
+                type: string
+            replicated:
+              properties:
+                size:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
+                targetSizeRatio:
+                  type: number
+                requireSafeReplicaSize:
+                  type: boolean
+            erasureCoded:
+              properties:
+                dataChunks:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
+                codingChunks:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
+            compressionMode:
+              type: string
+              enum:
+              - ""
+              - none
+              - passive
+              - aggressive
+              - force
+            enableRBDStats:
+              description: EnableRBDStats is used to enable gathering of statistics
+                for all RBD images in the pool
+              type: boolean
+            parameters:
+              type: object
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumes.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: Volume
+    listKind: VolumeList
+    plural: volumes
+    singular: volume
+    shortNames:
+    - rv
+  scope: Namespaced
+  version: v1alpha2
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: objectbuckets.objectbucket.io
+spec:
+  group: objectbucket.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  names:
+    kind: ObjectBucket
+    listKind: ObjectBucketList
+    plural: objectbuckets
+    singular: objectbucket
+    shortNames:
+      - ob
+      - obs
+  scope: Cluster
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: objectbucketclaims.objectbucket.io
+spec:
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  group: objectbucket.io
+  names:
+    kind: ObjectBucketClaim
+    listKind: ObjectBucketClaimList
+    plural: objectbucketclaims
+    singular: objectbucketclaim
+    shortNames:
+      - obc
+      - obcs
+  scope: Namespaced
+  subresources:
+    status: {}

--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -1,0 +1,411 @@
+## Rook Ceph Version Upgrade 1.3.6 to 1.4.2
+
+> 본 문서는 rook ceph v1.3.6에서 rook ceph v1.4.2로 업그레이드하는 방법을 다룹니다.
+
+### Kubernetes 및 HyperSDS 버전 설명
+
+- Kubernetes 버전은 1.17 이상이어야 합니다.
+- HyperSDS는 `release-1.3`에서 rook ceph v1.3.6을 사용합니다.
+- 본 문서는 HyperSDS release-1.3이 설치되어 있는 환경에서 rook과 ceph, ceph-csi의 버전을 업그레이드하는 방법을 다룹니다.
+
+### 주의사항
+
+- Rook ceph 버전 업그레이드를 수행할 경우, 예상치 못한 issue가 발생할 수도 있으므로, 중요한 데이터는 백업 후 업그레이드를 수행하는 것을 권장합니다.
+- 업그레이드를 진행하는 동안에는, ceph volume 생성, 변경, 이용 등의 작업을 중단하시는 것을 권장합니다.
+- <strong> 반드시 각 단계가 완료된 후, 다음 단계를 진행해주시길 바랍니다.</strong>
+
+### Rook Ceph Upgrade
+> Rook ceph version -> Ceph csi version -> Ceph version 순서로 업그레이드를 진행합니다.
+
+
+#### 1. Rook ceph cluster 상태 확인
+
+- 업그레이드 시작 전에 rook ceph cluster 상태를 확인합니다.
+	- Rook ceph 관련 Pod들이 모두 정상적으로 수행되고 있는지 확인합니다.
+	- Ceph command를 통해 rook ceph cluster의 상태를 확인합니다.
+		- Ceph cluster의 heath status가 HEALTH_OK인지 확인합니다.
+		- Ceph mon들이 모두 quorum에 포함되어 있는지 확인합니다.
+		- Ceph mgr이 active 상태인지 확인합니다.
+		- 모든 ceph osd들이 up & in 상태인지 확인합니다.
+		- 모든 pg가 active + clean 상태인지 확인합니다.
+		- Ceph mds가 active 상태인지 확인합니다.
+		
+	```shell
+    # Rook ceph cluster를 구성하는 pod들이 모두 RUNNING 상태인지 확인합니다.
+    $ kubectl -n rook-ceph get pods -o wide
+	
+	# Ceph command인 "ceph status"를 사용하여, ceph cluster의 상태를 확인합니다.
+    # Rook ceph toolbox pod를 통해서 ceph command를 입력할 수 있습니다.
+	# Rook ceph toolbox pod의 이름은 환경마다 다르므로, 해당 환경에서의 toolbox pod의 이름을 꼭 확인해주세요.
+	$ kubectl exec -it -n rook-ceph rook-ceph-tools-847744596b-cdv9m  -- ceph status
+	cluster:
+      id:     14f3596b-7429-45a5-9061-1ea33de648e1
+      health: HEALTH_OK
+
+    services:
+      mon: 1 daemons, quorum a (age 18m)
+      mgr: a(active, since 18m)
+      mds: myfs:1 {0=myfs-b=up:active} 1 up:standby-replay
+      osd: 3 osds: 3 up (since 17m), 3 in (since 17m)
+
+    data:
+      pools:   3 pools, 96 pgs
+      objects: 22 objects, 2.2 KiB
+      usage:   3.0 GiB used, 747 GiB / 750 GiB avail
+      pgs:     96 active+clean
+	
+
+#### 2. Alpha version의 snapshot 제거
+> Rook ceph v1.4부터는 ceph-csi v3.0 이상이 권장되므로, ceph-csi v2.0에서 사용하던 v1alpha1 API version의 snapshot이 호환되지 않습니다. 
+> 따라서 v1alpha1 snapshot 및 snapshot CRD가 있다면 제거하는 작업이 필요합니다.
+
+- STEP A) Snapshot 관련 CRD들의 API version이 v1alpha1인지 확인합니다.
+
+	```shell
+	# VolumeSnapshotClass의 API version이 v1alpha1인지 확인합니다.
+	$ kubectl get crd volumesnapshotclasses.snapshot.storage.k8s.io -o yaml |grep v1alpha1
+      - name: v1alpha1
+      - v1alpha1
+	# VolumeSnapshotContent의 API version이 v1alpha1인지 확인합니다.
+	$ kubectl get crd volumesnapshotcontents.snapshot.storage.k8s.io -o yaml |grep v1alpha1
+      - name: v1alpha1
+      - v1alpha1
+	# VolumeSnapshot의 API version이 v1alpha1인지 확인합니다.
+	$ kubectl get crd volumesnapshots.snapshot.storage.k8s.io -o yaml |grep v1alpha1
+      - name: v1alpha1
+      - v1alpha1
+	```
+	
+- STEP B) Snapshot API version이 v1alpha1이라면 존재하는 snapshot 관련 오브젝트들을 제거합니다.
+
+	```shell
+	# API version이 v1alpha1였다면, snapshot이 존재하는지 확인합니다.
+	$ kubectl get volumesnapshot
+	NAME               AGE
+	rbd-pvc-snapshot   22s
+	
+	# 존재한다면, 해당 snapshot을 제거해줍니다.
+	$ kubectl delete volumesnapshot rbd-pvc-snapshot
+	volumesnapshot.snapshot.storage.k8s.io "rbd-pvc-snapshot" deleted
+	
+	# 위의 과정을 volumesnapshotcontent, volumesnapshotclass에 대해서도 수행해줍니다.
+	```
+	
+- STEP C) Snapshot API version이 v1alpha1이라면 snapshot 관련 CRD들을 제거합니다.
+
+	```shell
+	# API version이 v1alpha1이라면 VolumeSnapshotClass CRD를 제거합니다.
+	$ kubectl delete crd volumesnapshotclasses.snapshot.storage.k8s.io 
+	customresourcedefinition.apiextensions.k8s.io "volumesnapshotclasses.snapshot.storage.k8s.io" deleted
+	
+	# API version이 v1alpha1이라면 VolumeSnapshotContent CRD를 제거합니다.
+	$ kubectl delete crd volumesnapshotcontents.snapshot.storage.k8s.io 
+	customresourcedefinition.apiextensions.k8s.io "volumesnapshotcontents.snapshot.storage.k8s.io" deleted
+	
+	# API version이 v1alpha1이라면 VolumeSnapshot CRD를 제거합니다.
+	$ kubectl delete crd volumesnapshots.snapshot.storage.k8s.io
+	customresourcedefinition.apiextensions.k8s.io "volumesnapshots.snapshot.storage.k8s.io" deleted
+	```
+
+
+#### 3. Beta version의 snapshot 설치
+> API version v1beta1의 snapshot 관련 CRD들과 controller를 설치합니다.
+
+- STEP A) v1beta1 API version의 snapshot CRD들을 설치합니다.
+
+	```shell
+	# v1beta1 API version의 VolumeSnapshot, VolumeSnapshotClass, VolumeSnapshotContent CRD를 설치합니다.
+	$ kubectl create -f 1_snapshot_crds.yaml
+	customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io created
+	customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io created
+	customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io created
+	```
+
+- STEP B) v1beta1 snapshot을 관리하는 controller 및 해당 controller의 RBAC 관련 오브젝트들을 설치합니다.
+	
+	```shell
+	# Snapshot controller의 ServiceAccount, ClusterRole 등 RBAC 관련 오브젝트들을 설치합니다.
+	$ kubectl create -f 2_snapshot_controller_rbac.yaml
+	serviceaccount/snapshot-controller created
+	clusterrole.rbac.authorization.k8s.io/snapshot-controller-runner created
+	clusterrolebinding.rbac.authorization.k8s.io/snapshot-controller-role created
+	role.rbac.authorization.k8s.io/snapshot-controller-leaderelection created
+	rolebinding.rbac.authorization.k8s.io/snapshot-controller-leaderelection created
+	
+	# Snapshot controller를 설치합니다.
+	$ kubectl create -f 3_snapshot_controller.yaml
+	statefulset.apps/snapshot-controller created
+	```
+
+
+#### 4. Rook v1.4 기준의 CRD와 RBAC 적용
+> Rook v1.3에서 쓰이던 CRD와 RBAC 관련 오브젝트들을 Rook v1.4 기준에 맞게 업그레이드합니다.
+
+- STEP A) Rook v1.4에서 변경된 ClusterRole들을 제거하고, v1.4 기준의 CRD와 RBAC 관련 오브젝트들을 설치합니다.
+
+	```shell
+	# Rook v1.3의 ClusterRole을 제거합니다.
+	$ kubectl delete -f 4_rook_rbac_v1_3.yaml
+	clusterrole.rbac.authorization.k8s.io "cephfs-csi-nodeplugin-rules" deleted
+	clusterrole.rbac.authorization.k8s.io "cephfs-external-provisioner-runner-rules" deleted
+	clusterrole.rbac.authorization.k8s.io "rbd-csi-nodeplugin-rules" deleted
+	...
+	
+	# Rook v1.4의 ServiceAccount, ClusterRole 등 RBAC 관련 오브젝트들을 설치합니다.
+	$ kubectl create -f 5_rook_rbac_v1_4.yaml
+	clusterrole.rbac.authorization.k8s.io/rook-ceph-global created
+	clusterrole.rbac.authorization.k8s.io/rook-ceph-cluster-mgmt created
+	clusterrole.rbac.authorization.k8s.io/rook-ceph-mgr-cluster created
+	...
+	
+	# Rook v1.4에서 사용되는 CRD들을 설치합니다.
+	$ kubectl create -f 6_rook_crds_v1_4.yaml
+	customresourcedefinition.apiextensions.k8s.io/cephrbdmirrors.ceph.rook.io created
+	customresourcedefinition.apiextensions.k8s.io/cephobjectrealms.ceph.rook.io created
+	customresourcedefinition.apiextensions.k8s.io/cephobjectzonegroups.ceph.rook.io created
+	...
+	
+	```
+
+
+#### 5. CSI version 업그레이드
+> CSI container image version을 ConfigMap에 직접 명시한 경우, image version을 수정해줘야 합니다.
+
+> <strong> 인벤토리의 `rook/operator.yaml`에서 CSI image version을 직접 기입하지 않았다면 다음 단계로 넘어가시기 바랍니다.</strong>
+
+> <strong> 혹은 별도로 `rook-ceph-operator-config` ConfigMap에 CSI image version을 직접 기입하지 않았다면 다음 단계로 넘어가시기 바랍니다.</strong>
+
+- STEP A) rook-ceph-operator-config ConfigMap에 이전 version의 CSI version들이 기입돼있는지 확인합니다.
+
+	```shell
+	# Rook v1.3.6에서 기본값으로 사용하는 CSI version은 아래와 같습니다.
+	# 만약 아무 값도 출력되지 않는다면, CSI version을 직접 명시하지 않은 경우입니다. 다음 단계로 넘어가시기 바랍니다.
+	$ kubectl -n rook-ceph get configmaps rook-ceph-operator-config -o yaml | grep -v f:ROOK_CSI_ | grep -v \"R | grep 'ROOK_CSI_.*_IMAGE'
+	  ROOK_CSI_ATTACHER_IMAGE: quay.io/k8scsi/csi-attacher:v2.1.0
+	  ROOK_CSI_CEPH_IMAGE: quay.io/cephcsi/cephcsi:v2.1.2
+	  ROOK_CSI_PROVISIONER_IMAGE: quay.io/k8scsi/csi-provisioner:v1.4.0
+	  ROOK_CSI_REGISTRAR_IMAGE: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+	  ROOK_CSI_RESIZER_IMAGE: quay.io/k8scsi/csi-resizer:v0.4.0
+	  ROOK_CSI_SNAPSHOTTER_IMAGE: quay.io/k8scsi/csi-snapshotter:v1.2.2
+	```
+
+- STEP B) rook-ceph-operator-config ConfigMap에서 CSI version을 최신으로 변경합니다.
+	- 현 단계에서는 rook operator yaml 파일의 내용만 수정하고, 실제 적용은 다음 단계인 6번에서 진행합니다.
+	- 업그레이드하고자 하는 ceph-csi 및 kubernetes-csi version은 다음과 같습니다.
+		- quay.io/cephcsi/cephcsi:v3.1.0
+		- quay.io/k8scsi/csi-attacher:v2.1.0
+		- quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+		- quay.io/k8scsi/csi-provisioner:v1.6.0
+		- quay.io/k8scsi/csi-resizer:v0.4.0
+		- quay.io/k8scsi/csi-snapshotter:v2.1.1
+
+	```shell
+	# CSI version을 ceph-csi v3.1.0에 맞춰 변경합니다.
+	# Ceph cluster 설치에 사용한 인벤토리의 rook/operator.yaml 파일에서 CSI image를 변경해줍니다.
+	# (예제에서는 /home/k8s/hypercloud-sds/hcsctl/my_inventory를 설치에 사용한 인벤토리라고 가정)
+	# rook-ceph-operator-config ConfigMap의 image만 변경하여 적용해주시기 바랍니다.
+	# (ROOK_CSI_*_IMAGE)
+	$ INVENTORY=/home/k8s/hypercloud-sds/hcsctl/my_inventory
+	$ cat $INVENTORY/rook/operator.yaml
+	
+	...
+	
+	kind: ConfigMap
+	apiVersion: v1
+	metadata:
+	  name: rook-ceph-operator-config
+	  # should be in the namespace of the operator
+	  namespace: rook-ceph
+	data:
+	
+	  ...
+	  
+	  # The default version of CSI supported by Rook will be started. To change the version
+	  # of the CSI driver to something other than what is officially supported, change
+	  # these images to the desired release of the CSI driver.
+	  ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v2.1.2"                        ## v3.1.0으로 변경합니다.
+	  ROOK_CSI_REGISTRAR_IMAGE: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+	  ROOK_CSI_RESIZER_IMAGE: "quay.io/k8scsi/csi-resizer:v0.4.0"
+	  ROOK_CSI_PROVISIONER_IMAGE: "quay.io/k8scsi/csi-provisioner:v1.4.0"          ## v1.6.0으로 변경합니다.
+	  ROOK_CSI_SNAPSHOTTER_IMAGE: "quay.io/k8scsi/csi-snapshotter:v1.2.2"          ## v2.1.1로 변경합니다.
+	  ROOK_CSI_ATTACHER_IMAGE: "quay.io/k8scsi/csi-attacher:v2.1.0"
+	  
+	...
+	
+	# Rook operator version을 업그레이드할 때 CSI version도 정상적으로 업그레이드되었는지 확인해야 합니다.
+	# 해당 커맨드는 6번에서 설명합니다.
+	```
+
+
+#### 6. Rook operator version 업그레이드
+
+- STEP A) 현재 ceph cluster를 구성하는 Deployment들의 rook version이 v1.3.6임을 확인합니다.
+
+	```shell
+	# ceph cluster를 구성하는 Deployment들이 rook v1.3.6임을 확인합니다.
+	# 모든 Deployment에 대하여 req/upd/avl: 1/1/1 값이 뜨면 정상적으로 작동하는 상태입니다.
+	$ kubectl -n rook-ceph get deployments -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+	rook-ceph-mds-myfs-a    req/upd/avl: 1/1/1      rook-version=v1.3.6
+	rook-ceph-mds-myfs-b    req/upd/avl: 1/1/1      rook-version=v1.3.6
+	rook-ceph-mgr-a         req/upd/avl: 1/1/1      rook-version=v1.3.6
+	rook-ceph-mon-a         req/upd/avl: 1/1/1      rook-version=v1.3.6
+	rook-ceph-osd-0         req/upd/avl: 1/1/1      rook-version=v1.3.6
+	rook-ceph-osd-1         req/upd/avl: 1/1/1      rook-version=v1.3.6
+	rook-ceph-osd-2         req/upd/avl: 1/1/1      rook-version=v1.3.6
+	```
+
+- STEP B) Rook ceph operator version을 v1.4.2로 업그레이드합니다.
+	
+	```shell
+	# rook operator의 version을 v1.4.2로 업그레이드합니다.
+	# Ceph cluster를 설치하는 데 사용한 인벤토리의 rook/operator.yaml 파일에서 Rook image를 변경해줍니다.
+	# (예제에서는 /home/k8s/hypercloud-sds/hcsctl/my_inventory를 설치에 사용한 인벤토리라고 가정)
+	# rook-ceph-operator Deployment의 image를 rook/ceph:v1.4.2 값으로 변경하여 적용해주시기 바랍니다.
+	# (spec.template.spec.containers[0].image)
+	$ INVENTORY=/home/k8s/hypercloud-sds/hcsctl/my_inventory
+	$ cat $INVENTORY/rook/operator.yaml
+	
+	...
+	
+	apiVersion: apps/v1
+	kind: Deployment
+	metadata:
+	  name: rook-ceph-operator
+	  namespace: rook-ceph
+	  labels:
+		operator: rook
+		storage-backend: ceph
+	spec:
+	
+	...
+	
+	      containers:
+		  - name: rook-ceph-operator
+			image: rook/ceph:v1.3.6    ## rook/ceph:v1.4.2 로 변경합니다.
+			args: ["ceph", "operator"]
+
+	...
+	
+	# 변경된 Rook version으로 재적용합니다.
+	$ kubectl apply -f $INVENTORY/rook/operator.yaml
+	configmap/rook-ceph-operator-config unchanged
+	deployment.apps/rook-ceph-operator configured
+	
+	# 위에서 확인했던 ceph cluster Deployment들이 모두 rook v1.4.2 version으로 업그레이드 되어 정상 작동하기까지 기다립니다.
+	# req/upd/avl 값이 1/1/1, rook-version 값이 v1.4.2가 되면 정상적으로 업그레이드된 상태입니다.
+	$ watch --exec kubectl -n rook-ceph get deployments -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+	
+	# 아래는 업그레이드 중일 때 출력되는 예시입니다. 
+	rook-ceph-mds-myfs-a    req/upd/avl: 1/1/1      rook-version=v1.3.6
+	rook-ceph-mds-myfs-b    req/upd/avl: 1/1/1      rook-version=v1.3.6
+	rook-ceph-mgr-a         req/upd/avl: 1//        rook-version=v1.4.2
+	rook-ceph-mon-a         req/upd/avl: 1/1/1      rook-version=v1.4.2
+	rook-ceph-osd-0         req/upd/avl: 1/1/1      rook-version=v1.3.6
+	rook-ceph-osd-1         req/upd/avl: 1/1/1      rook-version=v1.3.6
+	rook-ceph-osd-2         req/upd/avl: 1/1/1      rook-version=v1.3.6
+	
+	# 만약 CSI version을 직접 업그레이드하였다면 아래 커맨드를 통해 변경된 CSI version으로 정상적으로 업그레이드되었는지 확인합니다.
+	$ kubectl -n rook-ceph get pod -o jsonpath='{range .items[*]}{range .spec.containers[*]}{.image}{"\n"}' -l 'app in (csi-rbdplugin,csi-rbdplugin-provisioner,csi-cephfsplugin,csi-cephfsplugin-provisioner)' | sort | uniq
+	
+	quay.io/cephcsi/cephcsi:v3.1.0
+	quay.io/k8scsi/csi-attacher:v2.1.0
+	quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+	quay.io/k8scsi/csi-provisioner:v1.6.0
+	quay.io/k8scsi/csi-resizer:v0.4.0
+	quay.io/k8scsi/csi-snapshotter:v2.1.1
+	```
+
+- STEP C) Toolbox Deployment의 rook version을 v1.4.2로 업그레이드합니다.
+
+	```shell
+	# Toolbox의 image version을 v1.4.2로 업그레이드합니다.
+	# (spec.template.spec.containers[0].image)
+	$ cat $INVENTORY/rook/toolbox.yaml
+	...
+	  template:
+		metadata:
+		  labels:
+			app: rook-ceph-tools
+		spec:
+		  dnsPolicy: ClusterFirstWithHostNet
+		  containers:
+		  - name: rook-ceph-tools
+			image: rook/ceph:v1.3.6   ## rook/ceph:v1.4.2 로 변경합니다.
+			command: ["/tini"]
+	...
+
+	# 변경된 Rook version으로 재적용합니다.
+	$ kubectl apply -f $INVENTORY/rook/toolbox.yaml
+	```
+
+
+#### 7. Ceph version 업그레이드
+> Rook v1.4.2는 Ceph 15.2.4(Octopus)를 배포합니다. Ceph major version을 업그레이드하는 것을 권장합니다.
+
+- STEP A) 현재 ceph cluster를 구성하는 Deployment들의 ceph version이 v14.2.9임을 확인합니다.
+
+	```shell
+	# ceph cluster를 구성하는 Deployment들이 ceph v14.2.9임을 확인합니다.
+	# 모든 Deployment에 대하여 req/upd/avl: 1/1/1 값이 뜨면 정상적으로 작동하는 상태입니다.
+	$ kubectl -n rook-ceph get deployments -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+	rook-ceph-mds-myfs-a    req/upd/avl: 1/1/1      ceph-version=14.2.9-0
+	rook-ceph-mds-myfs-b    req/upd/avl: 1/1/1      ceph-version=14.2.9-0
+	rook-ceph-mgr-a         req/upd/avl: 1/1/1      ceph-version=14.2.9-0
+	rook-ceph-mon-a         req/upd/avl: 1/1/1      ceph-version=14.2.9-0
+	rook-ceph-osd-0         req/upd/avl: 1/1/1      ceph-version=14.2.9-0
+	rook-ceph-osd-1         req/upd/avl: 1/1/1      ceph-version=14.2.9-0
+	rook-ceph-osd-2         req/upd/avl: 1/1/1      ceph-version=14.2.9-0
+	```
+	
+- STEP B) Ceph cluster의 Ceph version을 v15.2.4로 업그레이드합니다.
+
+	```shell
+	# Ceph cluster를 설치하는 데 사용한 인벤토리의 rook/cluster.yaml 파일에서,
+	# image 값을 ceph/ceph:v15.2.4 값으로 변경하여 적용해주시기 바랍니다. (spec.cephVersion.image)
+	# (예제에서는 /home/k8s/hypercloud-sds/hcsctl/my_inventory를 설치에 사용한 인벤토리라고 가정)
+	$ INVENTORY=/home/k8s/hypercloud-sds/hcsctl/my_inventory
+	$ cat $INVENTORY/rook/cluster.yaml
+	kind: CephCluster
+	metadata:
+	  name: rook-ceph
+	  namespace: rook-ceph
+	spec:
+	  cephVersion:
+		image: ceph/ceph:v14.2.9	## ceph/ceph:v15.2.4 로 바꿔줍니다.
+		allowUnsupported: true
+	  dataDirHostPath: /var/lib/rook
+	...
+	
+	# 변경된 Ceph version으로 재적용합니다.
+	$ kubectl apply -f $INVENTORY/rook/cluster.yaml
+	cephcluster.ceph.rook.io/rook-ceph configured
+	
+	# 위에서 확인했던 ceph cluster Deployment들이 모두 ceph v15.2.4 version으로 업그레이드 되어 정상 작동하기까지 기다립니다.
+	$ watch --exec kubectl -n rook-ceph get deployments -l rook_cluster=rook-ceph -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+	
+	# 아래는 업그레이드 중일 때 출력되는 예시입니다.
+	rook-ceph-mds-myfs-a    req/upd/avl: 1/1/1      ceph-version=14.2.9-0
+	rook-ceph-mds-myfs-b    req/upd/avl: 1/1/1      ceph-version=14.2.9-0
+	rook-ceph-mgr-a         req/upd/avl: 1//        ceph-version=15.2.4-0
+	rook-ceph-mon-a         req/upd/avl: 1/1/1      ceph-version=15.2.4-0
+	rook-ceph-osd-0         req/upd/avl: 1/1/1      ceph-version=14.2.9-0
+	rook-ceph-osd-1         req/upd/avl: 1/1/1      ceph-version=14.2.9-0
+	rook-ceph-osd-2         req/upd/avl: 1/1/1      ceph-version=14.2.9-0
+	```
+
+
+### 업그레이드 완료 후의 image version
+- Rook version
+	- rook/ceph:v1.4.2
+	- Rook Ceph Upgrade 항목의 6번에 Rook version 확인하는 방법이 있습니다.
+- Ceph version
+	- ceph/ceph:v15.2.4
+	- Rook Ceph Upgrade 항목의 7번에 Ceph version 확인하는 방법이 있습니다.
+- CSI version
+	- quay.io/cephcsi/cephcsi:v3.1.0
+	- quay.io/k8scsi/csi-attacher:v2.1.0
+	- quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+	- quay.io/k8scsi/csi-provisioner:v1.6.0
+	- quay.io/k8scsi/csi-resizer:v0.4.0
+	- quay.io/k8scsi/csi-snapshotter:v2.1.1
+	- Rook Ceph Upgrade 항목의 6번에 CSI version 확인하는 방법이 있습니다.


### PR DESCRIPTION
Upgrade Rook, Ceph and if needed, CSI versions
- Rook: v1.3.6 -> v1.4.2
- Ceph: v14.2.9 -> v15.2.4
- Ceph-CSI: v2.1.2 -> v3.1.0 (Other k8s-csi versions are also updated according to ceph-csi version)
    - CSI version upgrade is required only when CSI versions are hard-coded in `rook-ceph-operator-config` ConfigMap

[skip-ci]

Signed-off-by: Taeuk Kim <taeuk_kim@tmax.co.kr>