### PR TITLE
Fix github action bugs

### DIFF
--- a/.github/workflows/hcsctl.yml
+++ b/.github/workflows/hcsctl.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           version: v1.29
           working-directory: hcsctl

--- a/hcsctl/e2e/cdi/cdi_test.go
+++ b/hcsctl/e2e/cdi/cdi_test.go
@@ -34,7 +34,7 @@ const (
 	StorageClassCephfs = "csi-cephfs-sc"
 
 	SampleRegistryURL = "docker://kubevirt/fedora-cloud-registry-disk-demo"
-	SampleHTTPURL     = "https://download.cirros-cloud.net/contrib/0.3.0/cirros-0.3.0-i386-disk.img"
+	SampleHTTPURL     = "https://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img"
 )
 
 var _ = Describe("Test CDI Module", func() {


### PR DESCRIPTION
- `set-env` command and `add-path` command is disabled in GitHub actions lately, but those commands are still used by golangci-lint plugin previous version, so update is needed. 
- github action is updated regularly. The version is up-to-date. 
- often timeout occurs while performing CDI testcase-2 which tests creating DV from http data source. Most likely it's because of cirros image we use for test is 3 years old, so the source to download the image is not stable. 