### PR TITLE
Github Action Bugfix

### DIFF
--- a/.github/workflows/hcsctl.yml
+++ b/.github/workflows/hcsctl.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           version: v1.29
           working-directory: hcsctl


### PR DESCRIPTION
- set-env command and add-path command is disabled in GitHub actions lately, but those commands are still used by golangci-lint plugin previous version, so update is needed.