### PR TITLE
Apply [skip-ci]

### DIFF
--- a/.github/workflows/hcsctl.yml
+++ b/.github/workflows/hcsctl.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   release:
     types:
       - published
@@ -23,6 +26,7 @@ jobs:
           version: v1.29
           working-directory: hcsctl
   build:
+    if: "! contains(github.event.pull_request.title, '[skip-ci]')"
     runs-on: prolinux
     timeout-minutes: 3
     needs: [lint]
@@ -39,6 +43,7 @@ jobs:
       - name: Build
         run: make
   e2e:
+    if: "! contains(github.event.pull_request.title, '[skip-ci]')"
     runs-on: prolinux
     needs: [build]
     timeout-minutes: 90


### PR DESCRIPTION
- for markdown files
- for all the files under docs directory
- for PR title includes [skip-ci]; For this case it'll only skip build and e2e test phase