### PR TITLE
Apply [skip-ci]

### DIFF
--- a/.github/workflows/hcsctl.yml
+++ b/.github/workflows/hcsctl.yml
@@ -6,6 +6,12 @@ on:
     tags:
       - v*
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  release:
+    types:
+      - published
 defaults:
   run:
     working-directory: hcsctl
@@ -22,6 +28,7 @@ jobs:
           version: v1.29
           working-directory: hcsctl
   build:
+    if: "! contains(github.event.pull_request.title, '[skip-ci]')"
     runs-on: prolinux
     timeout-minutes: 3
     needs: [lint]
@@ -38,6 +45,7 @@ jobs:
       - name: Build
         run: make
   e2e:
+    if: "! contains(github.event.pull_request.title, '[skip-ci]')"
     runs-on: prolinux
     needs: [build]
     timeout-minutes: 90


### PR DESCRIPTION
- for markdown files
- for all the files under docs directory
- for PR title includes [skip-ci]; For this case it'll only skip build and e2e test phase