### PR TITLE
Update k8s version for e2e test environment

### DIFF
--- a/.github/workflows/hcsctl.yml
+++ b/.github/workflows/hcsctl.yml
@@ -50,8 +50,7 @@ jobs:
     strategy:
       matrix:
         config:
-        - {k8s: v1.17.9, network: calico}
-        - {k8s: v1.17.9, network: flannel}
+        - {k8s: v1.19.4, network: calico}
     steps:
       - run: |
           export BOX_OS=prolinux KUBE_VERSION=${{ matrix.config.k8s }} KUBE_NETWORK=${{ matrix.config.network }}

--- a/hack/prolinux_cluster.sh
+++ b/hack/prolinux_cluster.sh
@@ -8,7 +8,8 @@ VM="VirtualBox"
 DEPLOYED_KUBE=( "prolinux_v1.15.3_calico" \
                 "prolinux_v1.17.9_calico" \
                 "prolinux_v1.15.3_flannel" \
-                "prolinux_v1.17.9_flannel" )
+                "prolinux_v1.17.9_flannel" \
+	        "prolinux_v1.19.4_calico" )
 
 # Check if VirtualBox vm is running
 is_vm_running(){


### PR DESCRIPTION
- remove k8s v1.17.9 test case
- add k8s v1.19.4 test case (only for calico CNI)